### PR TITLE
zest: collect stdout for script diagnostics

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Capture browser screenshots on Zest client step failures for script automation diagnostics.
+- Print output from Zest scripts is now captured and included in Script Diagnostics report sections. For chain runs, each output is attributed to the script within the chain that produced it.
 
 ### Changed
 - Update minimum `scripts` add-on version to 45.19.0.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.zest;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.script.ScriptException;
@@ -58,6 +59,9 @@ public class ZestScriptWrapper extends ScriptWrapper implements ScriptDiagnostic
 
     /** Last run failure diagnostics; cleared at run start and not copied by {@link #clone()}. */
     private RunFailureDiagnostic lastRunFailure;
+
+    private final List<RunOutput> runOutputs = new ArrayList<>();
+    private int runOutputOrdinal;
 
     public ZestScriptWrapper(ScriptWrapper script) {
         this.original = script;
@@ -288,11 +292,24 @@ public class ZestScriptWrapper extends ScriptWrapper implements ScriptDiagnostic
 
     @Override
     public List<RunOutput> getRunOutputs() {
-        return List.of();
+        return List.copyOf(runOutputs);
     }
 
     @Override
     public void clearRunDiagnostics() {
         lastRunFailure = null;
+        runOutputs.clear();
+        runOutputOrdinal = 0;
+    }
+
+    void appendRunOutput(
+            String scriptName, int sourceStatementIndex, String elementType, String message) {
+        runOutputs.add(
+                new RunOutput(
+                        scriptName,
+                        sourceStatementIndex,
+                        runOutputOrdinal++,
+                        elementType == null ? "" : elementType,
+                        message));
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -59,6 +59,7 @@ import org.zaproxy.zap.extension.scripts.diagnostics.ScriptDiagnosticSource.RunF
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ClientAuthenticator;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+import org.zaproxy.zap.extension.zest.internal.ZestScriptMerger;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zest.core.v1.ZestAction;
 import org.zaproxy.zest.core.v1.ZestActionFail;
@@ -92,6 +93,10 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     private ExtensionZest extension;
     private final ExtensionNetwork extensionNetwork;
     private ZestScriptWrapper wrapper = null;
+    private ZestStatement executingStatement;
+
+    /** Last resolved stdout attribution; used when output occurs outside a statement. */
+    private OutputAttribution lastOutputAttribution;
 
     /** Set when {@link #setWrapper} runs; provenance does not change during a run. */
     private boolean chainedScriptRun;
@@ -331,6 +336,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
             return null;
         }
         try {
+            executingStatement = stmt;
             return super.runStatement(script, stmt, lastResponse);
         } catch (ZestAssertFailException
                 | ZestActionFailException
@@ -341,6 +347,11 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
                 | RuntimeException e) {
             recordStatementFailureContext(stmt, e);
             throw e;
+        } finally {
+            if (stmt != null) {
+                lastOutputAttribution = outputAttribution(stmt);
+            }
+            executingStatement = null;
         }
     }
 
@@ -801,8 +812,85 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
         chainedScriptRun = this.wrapper.getChainProvenance().isPresent();
     }
 
-    private static void resetFailureDiagnosticsForNewRun(ZestScriptWrapper w) {
+    private void resetFailureDiagnosticsForNewRun(ZestScriptWrapper w) {
         w.clearRunDiagnostics();
+        lastOutputAttribution = null;
+    }
+
+    @Override
+    public void output(String str) {
+        super.output(str);
+        recordRunOutput(str);
+    }
+
+    @Override
+    public void debug(String str) {
+        super.debug(str);
+        if (this.wrapper.isDebug()) {
+            recordRunOutput("DEBUG: " + str);
+        }
+    }
+
+    private void recordRunOutput(String line) {
+        if (StringUtils.isEmpty(line)) {
+            return;
+        }
+        OutputAttribution attribution = outputAttribution(executingStatement);
+        if (executingStatement != null) {
+            lastOutputAttribution = attribution;
+        }
+        wrapper.appendRunOutput(
+                attribution.scriptName(),
+                attribution.sourceStatementIndex(),
+                attribution.elementType(),
+                line);
+    }
+
+    private record OutputAttribution(
+            String scriptName, int sourceStatementIndex, String elementType) {}
+
+    private OutputAttribution outputAttribution(ZestStatement stmt) {
+        if (stmt == null) {
+            if (lastOutputAttribution != null) {
+                return lastOutputAttribution;
+            }
+            return wrapper.getChainProvenance()
+                    .flatMap(provenance -> provenance.segmentScriptName(0))
+                    .map(name -> new OutputAttribution(name, -1, ""))
+                    .orElseGet(() -> new OutputAttribution(wrapper.getName(), -1, ""));
+        }
+        var chainProvOpt = wrapper.getChainProvenance();
+        if (chainProvOpt.isEmpty()) {
+            return new OutputAttribution(
+                    wrapper.getName(),
+                    stmt.getIndex(),
+                    StringUtils.defaultString(stmt.getElementType()));
+        }
+        ZestScriptMerger.ChainProvenance chainProv = chainProvOpt.get();
+        String fallbackScriptName = wrapper.getName();
+        return chainProv
+                .originForExecutingStatement(wrapper.getZestScript(), stmt)
+                .or(() -> chainProv.originForMergedIndex(stmt.getIndex()))
+                .map(origin -> attributionFromOrigin(chainProv, origin, fallbackScriptName))
+                .orElseGet(() -> chainOutputAttributionFallback(chainProv, stmt));
+    }
+
+    private static OutputAttribution attributionFromOrigin(
+            ZestScriptMerger.ChainProvenance chainProv,
+            ZestScriptMerger.ChainProvenance.StatementOrigin origin,
+            String fallbackScriptName) {
+        return new OutputAttribution(
+                chainProv.segmentScriptName(origin.segmentIndex()).orElse(fallbackScriptName),
+                origin.originalStatementIndex(),
+                StringUtils.defaultString(origin.elementType()));
+    }
+
+    private OutputAttribution chainOutputAttributionFallback(
+            ZestScriptMerger.ChainProvenance chainProv, ZestStatement stmt) {
+        return new OutputAttribution(
+                chainProv.segmentScriptName(0).orElse(wrapper.getName()),
+                -1,
+                StringUtils.defaultString(stmt.getElementType()));
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/ZestScriptMerger.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/internal/ZestScriptMerger.java
@@ -293,6 +293,14 @@ public final class ZestScriptMerger {
             return Optional.ofNullable(byZestStatementIndex.get(zestStatementIndex));
         }
 
+        /** Script name for a chain segment index, when in range. */
+        public Optional<String> segmentScriptName(int segmentIndex) {
+            if (segmentIndex < 0 || segmentIndex >= segments.size()) {
+                return Optional.empty();
+            }
+            return Optional.of(segments.get(segmentIndex).scriptName());
+        }
+
         /**
          * Resolves provenance for a statement during merged-chain execution. Uses {@link
          * #originForMergedIndex(int)} on {@code stmt.getIndex()}, then matches {@code stmt} by

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestScriptWrapperUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestScriptWrapperUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.zest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -105,8 +106,7 @@ class ZestScriptWrapperUnitTest {
         assertThat(clone.getUser(), is(nullValue()));
     }
 
-    @Test
-    void shouldNotCopyLastRunDiagnosticOntoClone() {
+    void shouldNotCopyLastRunFailureOntoClone() {
         ZestScriptWrapper wrapper = new ZestScriptWrapper(createMockScriptWrapper());
         wrapper.setLastRunFailure(
                 new RunFailureDiagnostic(
@@ -118,14 +118,14 @@ class ZestScriptWrapperUnitTest {
     }
 
     @Test
-    void shouldReturnEmptyLastRunDiagnosticWhenNoFailureRecorded() {
+    void shouldReturnEmptyLastRunFailureWhenNoFailureRecorded() {
         ZestScriptWrapper wrapper = new ZestScriptWrapper(createMockScriptWrapper());
 
         assertThat(wrapper.getLastRunFailure().isPresent(), is(false));
     }
 
     @Test
-    void shouldReturnLastRunDiagnosticSnapshot() {
+    void shouldReturnLastRunFailureSnapshot() {
         ZestScriptWrapper wrapper = new ZestScriptWrapper(createMockScriptWrapper());
         wrapper.setLastRunFailure(
                 new RunFailureDiagnostic(
@@ -143,13 +143,26 @@ class ZestScriptWrapperUnitTest {
     }
 
     @Test
-    void shouldClearLastRunDiagnostic() {
+    void shouldClearLastRunFailureAndRunOutputs() {
         ZestScriptWrapper wrapper = new ZestScriptWrapper(createMockScriptWrapper());
-        wrapper.setLastRunFailure(
-                new RunFailureDiagnostic("ctx", "detail", 1, 0, "ZestFoo", null));
+        wrapper.setLastRunFailure(new RunFailureDiagnostic("ctx", "detail", 1, 0, "ZestFoo", null));
+        wrapper.appendRunOutput("script", 0, "ZestFoo", "line one");
 
         wrapper.clearRunDiagnostics();
 
         assertThat(wrapper.getLastRunFailure().isPresent(), is(false));
+        assertThat(wrapper.getRunOutputs(), hasSize(0));
+    }
+
+    @Test
+    void shouldAppendRunOutputsWithOrdinal() {
+        ZestScriptWrapper wrapper = new ZestScriptWrapper(createMockScriptWrapper());
+        wrapper.appendRunOutput("script-a", 1, "ZestActionPrint", "first");
+        wrapper.appendRunOutput("script-a", 2, "ZestActionPrint", "second");
+
+        assertThat(wrapper.getRunOutputs(), hasSize(2));
+        assertThat(wrapper.getRunOutputs().get(0).ordinal(), is(equalTo(0)));
+        assertThat(wrapper.getRunOutputs().get(0).message(), is(equalTo("first")));
+        assertThat(wrapper.getRunOutputs().get(1).ordinal(), is(equalTo(1)));
     }
 }

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapRunnerUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapRunnerUnitTest.java
@@ -427,6 +427,146 @@ class ZestZapRunnerUnitTest extends TestUtils {
         m.invoke(runner, stmt, t);
     }
 
+    @Test
+    void shouldRecordStdoutOutputWithStandaloneAttribution() {
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.empty());
+        given(wrapper.getName()).willReturn("zest-script");
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+
+        runner.output("logged in");
+
+        verify(wrapper).appendRunOutput("zest-script", -1, "", "logged in");
+    }
+
+    @Test
+    void shouldRecordStdoutOutputWithChainAttribution() {
+        ZestScriptMerger.ChainProvenance provenance = mock(ZestScriptMerger.ChainProvenance.class);
+        ZestScriptMerger.ChainProvenance.StatementOrigin origin =
+                new ZestScriptMerger.ChainProvenance.StatementOrigin(1, 5, "ZestActionPrint");
+        ZestScript merged = mock(ZestScript.class);
+        ZestStatement stmt = mock(ZestStatement.class);
+        given(provenance.originForExecutingStatement(merged, stmt)).willReturn(Optional.of(origin));
+        given(provenance.segmentScriptName(1)).willReturn(Optional.of("nav-script"));
+
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.of(provenance));
+        given(wrapper.getZestScript()).willReturn(merged);
+
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+        setExecutingStatement(runner, stmt);
+
+        runner.output("chain line");
+
+        verify(wrapper).appendRunOutput("nav-script", 5, "ZestActionPrint", "chain line");
+    }
+
+    @Test
+    void shouldRecordStdoutOutputWithChainAttributionWhenExecutingLookupMisses() {
+        ZestScriptMerger.ChainProvenance provenance = mock(ZestScriptMerger.ChainProvenance.class);
+        ZestScriptMerger.ChainProvenance.StatementOrigin origin =
+                new ZestScriptMerger.ChainProvenance.StatementOrigin(1, 5, "ZestActionPrint");
+        ZestScript merged = mock(ZestScript.class);
+        ZestStatement stmt = mock(ZestStatement.class);
+        given(stmt.getIndex()).willReturn(99);
+        given(provenance.originForExecutingStatement(merged, stmt)).willReturn(Optional.empty());
+        given(provenance.originForMergedIndex(99)).willReturn(Optional.of(origin));
+        given(provenance.segmentScriptName(1)).willReturn(Optional.of("nav-script"));
+
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.of(provenance));
+        given(wrapper.getZestScript()).willReturn(merged);
+
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+        setExecutingStatement(runner, stmt);
+
+        runner.output("chain line");
+
+        verify(wrapper).appendRunOutput("nav-script", 5, "ZestActionPrint", "chain line");
+    }
+
+    @Test
+    void shouldRecordStdoutOutputUsingFirstSegmentWhenChainProvenanceUnknown() {
+        ZestScriptMerger.ChainProvenance provenance = mock(ZestScriptMerger.ChainProvenance.class);
+        ZestScript merged = mock(ZestScript.class);
+        ZestStatement stmt = mock(ZestStatement.class);
+        given(stmt.getIndex()).willReturn(99);
+        given(stmt.getElementType()).willReturn("ZestActionPrint");
+        given(provenance.originForExecutingStatement(merged, stmt)).willReturn(Optional.empty());
+        given(provenance.originForMergedIndex(99)).willReturn(Optional.empty());
+        given(provenance.segmentScriptName(0)).willReturn(Optional.of("account_check"));
+
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.of(provenance));
+        given(wrapper.getZestScript()).willReturn(merged);
+
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+        setExecutingStatement(runner, stmt);
+
+        runner.output("chain line");
+
+        verify(wrapper).appendRunOutput("account_check", -1, "ZestActionPrint", "chain line");
+    }
+
+    @Test
+    void shouldRecordStdoutOutputUsingWrapperNameWhenSegmentNameMissing() {
+        ZestScriptMerger.ChainProvenance provenance = mock(ZestScriptMerger.ChainProvenance.class);
+        ZestScriptMerger.ChainProvenance.StatementOrigin origin =
+                new ZestScriptMerger.ChainProvenance.StatementOrigin(1, 5, "ZestActionPrint");
+        ZestScript merged = mock(ZestScript.class);
+        ZestStatement stmt = mock(ZestStatement.class);
+        given(provenance.originForExecutingStatement(merged, stmt)).willReturn(Optional.of(origin));
+        given(provenance.segmentScriptName(1)).willReturn(Optional.empty());
+
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.of(provenance));
+        given(wrapper.getZestScript()).willReturn(merged);
+        given(wrapper.getName()).willReturn("merged-chain");
+
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+        setExecutingStatement(runner, stmt);
+
+        runner.output("chain line");
+
+        verify(wrapper).appendRunOutput("merged-chain", 5, "ZestActionPrint", "chain line");
+    }
+
+    @Test
+    void shouldReuseLastOutputAttributionWhenExecutingStatementCleared() throws Exception {
+        ZestScriptMerger.ChainProvenance provenance = mock(ZestScriptMerger.ChainProvenance.class);
+        ZestScriptMerger.ChainProvenance.StatementOrigin origin =
+                new ZestScriptMerger.ChainProvenance.StatementOrigin(1, 5, "ZestActionPrint");
+        ZestScript merged = mock(ZestScript.class);
+        ZestStatement stmt = mock(ZestStatement.class);
+        given(provenance.originForExecutingStatement(merged, stmt)).willReturn(Optional.of(origin));
+        given(provenance.segmentScriptName(1)).willReturn(Optional.of("nav-script"));
+
+        ZestScriptWrapper wrapper = mock(ZestScriptWrapper.class);
+        given(wrapper.getChainProvenance()).willReturn(Optional.of(provenance));
+        given(wrapper.getZestScript()).willReturn(merged);
+
+        ZestZapRunner runner = new ZestZapRunner(extensionZest, extensionNetwork, wrapper);
+        setExecutingStatement(runner, stmt);
+        runner.output("during statement");
+        setExecutingStatement(runner, null);
+
+        runner.output("between statements");
+
+        verify(wrapper).appendRunOutput("nav-script", 5, "ZestActionPrint", "during statement");
+        verify(wrapper).appendRunOutput("nav-script", 5, "ZestActionPrint", "between statements");
+    }
+
+    private static void setExecutingStatement(ZestZapRunner runner, ZestStatement stmt) {
+        try {
+            java.lang.reflect.Field field =
+                    ZestZapRunner.class.getDeclaredField("executingStatement");
+            field.setAccessible(true);
+            field.set(runner, stmt);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     // Test implementation that implements both interfaces to ensure instanceof works
     private abstract static class TestClientAuthenticatorMethod extends AuthenticationMethod
             implements ClientAuthenticator {}


### PR DESCRIPTION
## Summary
- Implement `ScriptDiagnosticSource` on `ZestScriptWrapper`
- Collect Zest print/debug output in `ZestZapRunner` with chain provenance attribution
- Clear diagnostics at run start and on chain merge

Stacked on `af/script-diags-scripts`. Upstream scripts PR: https://github.com/zaproxy/zap-extensions/pull/7452

## Test plan
- [x] `./gradlew :addOns:zest:test --tests "org.zaproxy.zap.extension.zest.ZestZapRunnerUnitTest"`
