### PR TITLE
reports: add script diagnostics output section

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Added a new section to Traditional JSON Report with Requests and Responses for script diagnostics.
+- Added new sections to Traditional JSON Report with Requests and Responses for script diagnostics information.
 - Templates that include Insights now also identify the Insight that stopped the scan, if applicable.
 
 ### Fixed

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/report-traditional-json-plus.html
@@ -33,6 +33,10 @@
 			<td>Screenshots for Script Diagnostics</td>
 			<td>scriptdiagnosticsscreenshots</td>
 		</tr>
+		<tr>
+			<td>Output for Script Diagnostics</td>
+			<td>scriptdiagnosticsoutput</td>
+		</tr>
 	</table>
 
 	<H3>Sample</H3>
@@ -236,8 +240,20 @@
 	<code>scriptDiagnostics</code>
 	object containing a
 	<code>runs</code>
-	array of script diagnostic records (for example failed automation
-	runs).
+	array of script diagnostic records. Each run has
+	<code>created</code>
+	,
+	<code>outcome</code>
+	(for example
+	<code>FAILED</code>
+	or
+	<code>SUCCESS</code>
+	),
+	<code>summary</code>
+	, and a
+	<code>scripts</code>
+	array.
+
 	<pre>
 	"scriptDiagnostics": {
 		"runs": [
@@ -270,8 +286,31 @@
 		]
 	}
 </pre>
-	More data can be included on failure steps depending on the additional
-	diagnostics sections enabled for the report.
+	More data can be included on steps depending on the additional
+	diagnostics sections enabled for the report, as outlined below.
+
+	<H4>Output for Script Diagnostics</H4>
+	Steps can include print output lines with kind
+	<code>OUTPUT</code>
+	. For example:
+
+	<pre>
+	{
+		"sourceStepIndex": 2,
+		"line": "ZestActionPrint",
+		"outputs": [
+			{
+				"kind": "OUTPUT",
+				"message": "In example_script"
+			}
+		]
+	}
+</pre>
+	When this section is disabled, steps still include
+	<code>ERROR</code>
+	output lines; only
+	<code>OUTPUT</code>
+	lines are omitted.
 
 	<H4>Screenshots for Script Diagnostics</H4>
 	When this section is enabled the step can, optionally, include a
@@ -282,4 +321,3 @@
 
 </BODY>
 </HTML>
-

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/Messages.properties
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/Messages.properties
@@ -1,6 +1,7 @@
 # i18n strings specific to this report template
 report.template.section.afstate = Automation Framework State
 report.template.section.scriptdiagnostics = Script Diagnostics
+report.template.section.scriptdiagnosticsoutput = Output for Script Diagnostics
 report.template.section.scriptdiagnosticsscreenshots = Screenshots for Script Diagnostics
 report.template.section.sequencedetails = Sequence Details
 report.template.section.statistics = Statistics

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/template.yaml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-json-plus/template.yaml
@@ -8,3 +8,4 @@ sections:
  - afstate
  - scriptdiagnostics
  - scriptdiagnosticsscreenshots
+ - scriptdiagnosticsoutput

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsJsonUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsJsonUnitTest.java
@@ -752,10 +752,9 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
 
         JSONArray alerts = site.getJSONObject(0).getJSONArray("alerts");
         assertThat(alerts.size(), is(equalTo(1)));
-        checkAlert(site.getJSONObject(0));
         JSONArray instances = alerts.getJSONObject(0).getJSONArray("instances");
         checkJsonAlertInstanceAndMessages(instances, 0);
-        checkJsonAlertInstanceAndMessages(instances, 0);
+        checkJsonAlertInstanceAndMessages(instances, 1);
 
         // tags are not included in non plus report
         JSONArray tags = alerts.getJSONObject(0).getJSONArray("tags");
@@ -817,10 +816,9 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
 
         // When
         File r = ReportTestUtils.generateReportWithScriptDiagnostics(template, f);
-        String report = new String(Files.readAllBytes(r.toPath()));
 
         // Then
-        JSONObject json = JSONObject.fromObject(report);
+        JSONObject json = readJsonReport(r);
         JSONObject scriptDiagnostics = json.getJSONObject("scriptDiagnostics");
         assertThat(scriptDiagnostics.containsKey("runs"), is(true));
         JSONArray runsJson = scriptDiagnostics.getJSONArray("runs");
@@ -892,14 +890,9 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
 
         // When
         File r = ReportTestUtils.generateReportWithScriptDiagnostics(template, f, runs);
-        String report = new String(Files.readAllBytes(r.toPath()));
 
         // Then — must parse as JSON and round-trip string values ([[${...}]] encoding)
-        JSONObject run =
-                JSONObject.fromObject(report)
-                        .getJSONObject("scriptDiagnostics")
-                        .getJSONArray("runs")
-                        .getJSONObject(0);
+        JSONObject run = scriptDiagnosticsRun(r, 0);
         assertScriptDiagnosticRunStructure(run);
         assertThat(run.getString("created"), is(equalTo(created)));
         assertThat(run.getString("outcome"), is(equalTo(outcome)));
@@ -945,6 +938,66 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
         assertThat(output.containsKey("detail"), is(false));
     }
 
+    private static JSONObject readJsonReport(File reportFile) throws IOException {
+        return JSONObject.fromObject(new String(Files.readAllBytes(reportFile.toPath())));
+    }
+
+    private static JSONObject scriptDiagnosticsRun(File report, int runIndex) throws IOException {
+        return readJsonReport(report)
+                .getJSONObject("scriptDiagnostics")
+                .getJSONArray("runs")
+                .getJSONObject(runIndex);
+    }
+
+    private static JSONObject firstScriptFromRun(File report, int runIndex) throws IOException {
+        return scriptDiagnosticsRun(report, runIndex).getJSONArray("scripts").getJSONObject(0);
+    }
+
+    private static JSONObject firstStepFromRun(File report, int runIndex) throws IOException {
+        return firstScriptFromRun(report, runIndex).getJSONArray("steps").getJSONObject(0);
+    }
+
+    @Test
+    void shouldOmitScriptDiagnosticStdoutWhenOutputSectionDisabled() throws Exception {
+        Template template = ReportTestUtils.getTemplateFromYamlFile("traditional-json-plus");
+        File f =
+                File.createTempFile(
+                        "traditional-json-plus-no-script-stdout", template.getExtension());
+
+        File r =
+                ReportTestUtils.generateReportWithScriptDiagnostics(
+                        template,
+                        f,
+                        true,
+                        List.of(ReportTestUtils.defaultScriptDiagnosticRunWithStdoutAndError()),
+                        "scriptdiagnosticsoutput");
+        JSONObject step = firstStepFromRun(r, 0);
+        JSONArray outputs = step.getJSONArray("outputs");
+        assertThat(outputs.size(), is(equalTo(1)));
+        assertThat(outputs.getJSONObject(0).getString("kind"), is(equalTo("ERROR")));
+        assertThat(outputs.getJSONObject(0).getString("message"), is(equalTo("boom")));
+    }
+
+    @Test
+    void shouldIncludeScriptDiagnosticStdoutWhenOutputSectionEnabled() throws Exception {
+        Template template = ReportTestUtils.getTemplateFromYamlFile("traditional-json-plus");
+        File f =
+                File.createTempFile("traditional-json-plus-script-stdout", template.getExtension());
+
+        File r =
+                ReportTestUtils.generateReportWithScriptDiagnostics(
+                        template,
+                        f,
+                        true,
+                        List.of(ReportTestUtils.defaultScriptDiagnosticRunWithStdout()));
+        JSONObject step = firstStepFromRun(r, 0);
+        JSONObject output = step.getJSONArray("outputs").getJSONObject(0);
+        assertThat(step.getInt("sourceStepIndex"), is(equalTo(3)));
+        assertThat(step.getString("line"), is(equalTo("ZestActionPrint")));
+        assertThat(output.getString("kind"), is(equalTo("OUTPUT")));
+        assertThat(output.getString("message"), is(equalTo("logged in")));
+    }
+
     @Test
     void shouldOmitScriptDiagnosticScreenshotWhenScreenshotsSectionDisabled() throws Exception {
         Template template = ReportTestUtils.getTemplateFromYamlFile("traditional-json-plus");
@@ -959,15 +1012,7 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
                         true,
                         List.of(ReportTestUtils.defaultScriptDiagnosticRunWithScreenshot()),
                         "scriptdiagnosticsscreenshots");
-        JSONObject step =
-                JSONObject.fromObject(new String(Files.readAllBytes(r.toPath())))
-                        .getJSONObject("scriptDiagnostics")
-                        .getJSONArray("runs")
-                        .getJSONObject(0)
-                        .getJSONArray("scripts")
-                        .getJSONObject(0)
-                        .getJSONArray("steps")
-                        .getJSONObject(0);
+        JSONObject step = firstStepFromRun(r, 0);
         assertThat(step.containsKey("screenshot"), is(equalTo(false)));
     }
 
@@ -988,11 +1033,8 @@ class ExtensionReportsJsonUnitTest extends TestUtils {
                         f,
                         false,
                         List.of(ReportTestUtils.defaultScriptDiagnosticRunWithScreenshot()));
-        String report = new String(Files.readAllBytes(r.toPath()));
-
         // Then
-        JSONObject json = JSONObject.fromObject(report);
+        JSONObject json = readJsonReport(r);
         assertThat(json.containsKey("scriptDiagnostics"), is(equalTo(false)));
-        assertThat(json.getJSONArray("site").size(), is(equalTo(0)));
     }
 }

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportTestUtils.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportTestUtils.java
@@ -37,6 +37,7 @@ import org.zaproxy.addon.insights.report.ExtensionInsightsReport;
 import org.zaproxy.zap.extension.alert.AlertNode;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.scripts.internal.db.ScriptRunRecorder;
+import org.zaproxy.zap.extension.scripts.internal.db.ScriptRunReportQuery;
 import org.zaproxy.zap.extension.scripts.report.ExtensionScriptsReport;
 import org.zaproxy.zap.extension.scripts.report.ScriptRunReportData;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -351,7 +352,12 @@ public class ReportTestUtils {
 
         reportData.addReportObjects(
                 ExtensionScriptsReport.SCRIPT_DIAGNOSTICS,
-                new ScriptRunReportData.Diagnostics(runs));
+                new ScriptRunReportData.Diagnostics(
+                        ScriptRunReportQuery.filterRunsForReport(
+                                runs,
+                                new ScriptRunReportQuery.Options(
+                                        sections.contains("scriptdiagnosticsscreenshots"),
+                                        sections.contains("scriptdiagnosticsoutput")))));
 
         return extRep.generateReport(reportData, template, f.getAbsolutePath(), false);
     }
@@ -383,6 +389,52 @@ public class ReportTestUtils {
 
     static ScriptRunReportData.Run defaultScriptDiagnosticRunWithScreenshot() {
         return defaultScriptDiagnosticRuns().get(1);
+    }
+
+    static ScriptRunReportData.Run defaultScriptDiagnosticRunWithStdout() {
+        return new ScriptRunReportData.Run(
+                "2026-04-03T10:00:00Z",
+                ScriptRunRecorder.OUTCOME_SUCCESS,
+                "Job: script completed",
+                List.of(
+                        new ScriptRunReportData.Script(
+                                1,
+                                "zest-script",
+                                "standalone",
+                                List.of(
+                                        new ScriptRunReportData.Step(
+                                                3,
+                                                "ZestActionPrint",
+                                                List.of(
+                                                        new ScriptRunReportData.Output(
+                                                                ScriptRunRecorder
+                                                                        .OUTPUT_KIND_OUTPUT,
+                                                                "logged in")))))));
+    }
+
+    static ScriptRunReportData.Run defaultScriptDiagnosticRunWithStdoutAndError() {
+        return new ScriptRunReportData.Run(
+                "2026-04-03T10:00:00Z",
+                ScriptRunRecorder.OUTCOME_FAILED,
+                "Job: failed after log",
+                List.of(
+                        new ScriptRunReportData.Script(
+                                1,
+                                "zest-script",
+                                "standalone",
+                                List.of(
+                                        new ScriptRunReportData.Step(
+                                                3,
+                                                "ZestActionPrint",
+                                                List.of(
+                                                        new ScriptRunReportData.Output(
+                                                                ScriptRunRecorder
+                                                                        .OUTPUT_KIND_OUTPUT,
+                                                                "logged in"),
+                                                        new ScriptRunReportData.Output(
+                                                                ScriptRunRecorder.OUTPUT_KIND_ERROR,
+                                                                "boom")),
+                                                null)))));
     }
 
     static ScriptRunReportData.Run scriptRunReport(


### PR DESCRIPTION
## Summary
- Add `scriptdiagnosticsoutput` section to Traditional JSON Plus template
- Document OUTPUT vs ERROR gating in help
- Add report unit tests and delegate filtering to `ScriptRunReportQuery`

Stacked on #12. 

## Test plan
- [x] `./gradlew :addOns:reports:test --tests "org.zaproxy.addon.reports.ExtensionReportsJsonUnitTest"`
- [ ] Merge after scripts and zest PRs